### PR TITLE
Add proper search path for release

### DIFF
--- a/RNDeviceSpecs.xcodeproj/project.pbxproj
+++ b/RNDeviceSpecs.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Fastlane build of the app failed because `RCTBridgeModule` couldnt be found for this module

@cgarvis @madwed 

do we want to bump the version after this is merged? 
