### PR TITLE
Add storageSize

### DIFF
--- a/RNDeviceSpecs.js
+++ b/RNDeviceSpecs.js
@@ -1,13 +1,11 @@
 import { NativeModules } from 'react-native';
-import closest from './closest';
+import closestSize from './closest-size';
 
 const NativeSpecs = NativeModules.RNDeviceSpecs;
-
-export const storageOptions = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1028];
-export const diskSpace = parseFloat(NativeSpecs.diskSpace);
+const diskSpace = parseFloat(NativeSpecs.diskSpace);
 
 export const RNDeviceSpecs = {
-  storageSize: closest(storageOptions, diskSpace),
+  storageSize: closestSize(diskSpace),
   diskSpace,
   carrier: NativeSpecs.carrier,
   platform: NativeSpecs.platform

--- a/RNDeviceSpecs.js
+++ b/RNDeviceSpecs.js
@@ -1,15 +1,14 @@
-/**
- * Stub of RNDeviceSpecs for Android.
- *
- * @providesModule RNDeviceSpecs
- * @flow
- */
-'use strict';
 import { NativeModules } from 'react-native';
-var NativeSpecs = NativeModules.RNDeviceSpecs;
+import closest from './closest';
 
-var RNDeviceSpecs = {
-  diskSpace: parseFloat(NativeSpecs.diskSpace),
+const NativeSpecs = NativeModules.RNDeviceSpecs;
+
+export const storageOptions = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1028];
+export const diskSpace = parseFloat(NativeSpecs.diskSpace);
+
+export const RNDeviceSpecs = {
+  storageSize: closest(storageOptions, diskSpace),
+  diskSpace,
   carrier: NativeSpecs.carrier,
   platform: NativeSpecs.platform
 };

--- a/closest-size.js
+++ b/closest-size.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const storageOptions = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1028];
+
+export default function closestSize(actualSize) {
+  return storageOptions.find( val => {
+    return val > actualSize ? val : false;
+  });
+}
+

--- a/closest.js
+++ b/closest.js
@@ -1,0 +1,9 @@
+'use strict';
+
+export default function closest(options, goal) {
+  return options.reduce((prev, curr) => {
+    var val = Math.abs(curr - goal) < Math.abs(prev - goal) ? curr : prev;
+    return val > goal ? val : prev;
+  });
+}
+

--- a/closest.js
+++ b/closest.js
@@ -1,9 +1,0 @@
-'use strict';
-
-export default function closest(options, goal) {
-  return options.reduce((prev, curr) => {
-    var val = Math.abs(curr - goal) < Math.abs(prev - goal) ? curr : prev;
-    return val > goal ? val : prev;
-  });
-}
-


### PR DESCRIPTION
This pulls storageSize out of the mobile app and returns it as part of the device specs.

Related to [sprintly 364](https://sprint.ly/product/37169/item/364)

> Update mobile app to use api for product identification.

@madwed @cgarvis 
